### PR TITLE
Added site URL config option (for email links, etc)

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,6 +10,8 @@ default[:buildingdb][:node][:user] = 'www-data'
 default[:buildingdb][:node][:group] = 'www-data'
 default[:buildingdb][:node][:environment] = 'production'
 
+default[:buildingdb][:site_url] = 'http://dev.polygon.city'
+
 default[:buildingdb][:mongodb][:version] = '2.6.8'
 default[:buildingdb][:mongodb][:port] = 27017
 default[:buildingdb][:mongodb][:host] = "localhost"

--- a/templates/default/config.js.erb
+++ b/templates/default/config.js.erb
@@ -3,6 +3,7 @@ var host = "<%= node[:buildingdb][:mongodb][:host] %>"
 var port = <%= node[:buildingdb][:mongodb][:port] %>
 var database = "<%= node[:buildingdb][:mongodb][:database] %>"
 module.exports = {
+  "siteURL": "<%= node[:buildingdb][:site_url] %>",
   "db": {
     "url": "mongodb://"+host+":"+port + "/" + database,
     "options": {


### PR DESCRIPTION
I noticed that we were seeing the wrong URLs in emails as Polygon City is missing a configuration option on the dev server. This fixes that and sets the default value to the dev server URL.
