### PR TITLE
Added config template for setting temporary directory path

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,6 +10,7 @@ default[:buildingdb][:node][:user] = 'www-data'
 default[:buildingdb][:node][:group] = 'www-data'
 default[:buildingdb][:node][:environment] = 'production'
 
+default[:buildingdb][:tmp_directory] = './tmp/'
 default[:buildingdb][:site_url] = 'http://dev.polygon.city'
 
 default[:buildingdb][:mongodb][:version] = '2.6.8'

--- a/recipes/app.rb
+++ b/recipes/app.rb
@@ -37,11 +37,17 @@ application node[:buildingdb][:application] do
       cwd "#{new_resource.release_path}"
       command "bower install --allow-root"
     end
+
+    execute "load mongodb indexes" do
+      cwd "#{new_resource.release_path}"
+      command "for file in `ls schema`; do mongo #{node[:buildingdb][:mongodb][:host]}/#{node[:buildingdb][:mongodb][:database]} -u #{node[:buildingdb][:mongodb][:user]} -p #{node[:buildingdb][:mongodb][:password]}  < schema/$file; done;"
+    end
   end
 
   symlinks "config/config.js" => "config/config.js",
-	   "config/setup.js" => "config/setup.js",
-	   "tmp" => "tmp"
+     "config/setup.js" => "config/setup.js",
+     "schema" => "schema",
+     "tmp" => "tmp"
 
   nodejs do
     template 'upstart.conf.erb'

--- a/templates/default/config.js.erb
+++ b/templates/default/config.js.erb
@@ -3,6 +3,9 @@ var host = "<%= node[:buildingdb][:mongodb][:host] %>"
 var port = <%= node[:buildingdb][:mongodb][:port] %>
 var database = "<%= node[:buildingdb][:mongodb][:database] %>"
 module.exports = {
+  <% if node[:buildingdb][:tmp_directory]
+  "tmpDirectory": "<%= node[:buildingdb][:tmp_directory] %>",
+  <% end %>
   "db": {
     "url": "mongodb://"+host+":"+port + "/" + database,
     "options": {

--- a/templates/default/config.js.erb
+++ b/templates/default/config.js.erb
@@ -4,6 +4,9 @@ var port = <%= node[:buildingdb][:mongodb][:port] %>
 var database = "<%= node[:buildingdb][:mongodb][:database] %>"
 module.exports = {
   "siteURL": "<%= node[:buildingdb][:site_url] %>",
+  <% if node[:buildingdb][:tmp_directory]
+  "tmpDirectory": "<%= node[:buildingdb][:tmp_directory] %>",
+  <% end %>
   "db": {
     "url": "mongodb://"+host+":"+port + "/" + database,
     "options": {

--- a/templates/default/config.js.erb
+++ b/templates/default/config.js.erb
@@ -4,9 +4,7 @@ var port = <%= node[:buildingdb][:mongodb][:port] %>
 var database = "<%= node[:buildingdb][:mongodb][:database] %>"
 module.exports = {
   "siteURL": "<%= node[:buildingdb][:site_url] %>",
-  <% if node[:buildingdb][:tmp_directory]
   "tmpDirectory": "<%= node[:buildingdb][:tmp_directory] %>",
-  <% end %>
   "db": {
     "url": "mongodb://"+host+":"+port + "/" + database,
     "options": {


### PR DESCRIPTION
This adds the template for setting the temporary directory, used to place the uploaded files and store model conversion files until they are put on S3 (local files are deleted after that).

The directory path needs to end with a "/" to work with some of the legacy code from this previously being un-configurable. For example:

```
"./tmp123/"
```

A lot of this will change in v2 of Polygon City anyway with a better, more robust upload flow and model conversion system.
